### PR TITLE
Removed python3 package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN yum update -y && \
             git \
             ca-certificates \
             tar \
-            python3 \
             nano
 
 # User Argument


### PR DESCRIPTION
Not necessary. Removed. Needs only for py-developers
Issue #23