### PR TITLE
Base command don't work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN yum update -y && \
             git \
             ca-certificates \
             tar \
-            nano
+            nano \
+            procps
 
 # User Argument
 ARG user=admin


### PR DESCRIPTION
There all right with paths in .zshrc
But `ps` and `top` commands inside of additional package named `procps`. Added the package to install list
Issue #32