### PR TITLE
First release with X-Server

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -48,3 +48,5 @@ PROMPT=' > [%F{yellow}%n%f] [%F{yellow}%m%f] [%F{yellow}%1~%f] [%F{yellow}$(pars
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"                        # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"      # This loads nvm bash_completion
+
+alias chromium-browser='chromium-browser --no-sandbox --disable-gpu --disable-dev-shm-usage --disable-webgl'

--- a/Desktop/Chrome.desktop
+++ b/Desktop/Chrome.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Chrome
+Comment=
+Exec=/usr/bin/chromium-browser --no-sandbox --disable-gpu --disable-dev-shm-usage --disable-webgl
+Icon=applications-internet
+Path=
+Terminal=false
+StartupNotify=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,19 +36,67 @@ RUN yum update -y && \
             ca-certificates \
             tar \
             nano \
-            procps
+            procps \
+            openssl \
+            mc
+
+# Install additional EPEL repository for xrdp and chromium packages
+RUN amazon-linux-extras install epel
+
+# Define XFCE4 for all users
+RUN bash -c 'echo PREFERRED=/usr/bin/xfce4-session > /etc/sysconfig/desktop'
+
+# Install xrdp, wrapper and helpers packages
+RUN yum install -y tigervnc-server \
+                   xrdp \
+                   xorgxrdp \
+                   xfce4-session \
+                   xfdesktop \
+                   xorg-x11-server-common \
+                   xorg-x11-drv-fbdev \
+                   xorg-x11-drv-vesa \
+                   dbus \
+                   xorg-x11-xinit-session \
+                   supervisor \
+                   xterm \
+                   upower \
+                   vulkan \
+                   liberation-fonts \
+                   wget \
+                   xdg-utils \
+                   bzip2
+
+# D-Bus env to have path to unix socket for child apps
+ENV DBUS_SESSION_BUS_ADDRESS="unix:path=/run/dbus/system_bus_socket"
+
+# Make XFCE4 default X-client
+RUN echo "xfce4-session" > /etc/skel/.Xclients
+
+# Permit to start X-server without console authentication
+COPY xrdp.conf /etc/supervisord.d/xrdp.ini
+COPY xrdp-sesman.conf /etc/supervisord.d/xrdp-sesman.ini
+COPY supervisord.conf /etc/
+
+# Install chromium browser
+RUN yum install -y chromium
+
+# Generate machineID for D-Bus subsystem
+RUN dbus-uuidgen > /etc/machine-id
+
+# Copy xorg.conf from RDP forder to common space
+RUN cp /etc/X11/xrdp/xorg.conf /etc/X11/
 
 # User Argument
 ARG user=admin
 
-# Create User
-RUN useradd -s /bin/bash "$user"
+# Create user and generate random password for
+RUN RPASS=`/usr/bin/openssl rand -base64 6` && useradd -s /bin/zsh -g wheel -p $(openssl passwd -1 "$RPASS") "$user" && echo "$user:$RPASS" > "/home/$user/.rdp_credentials"
 
 # Ensrue User can sudo
 RUN echo "$user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Ensure that user owns their won home directory
-RUN chown -R "$user:$user" "/home/$user/"
+RUN chown -R "$user:wheel" "/home/$user/"
 
 # Copy github_check script to container
 COPY check_commit_add.sh /usr/bin/check_commit_add.sh
@@ -58,8 +106,24 @@ COPY check_commit.sh /usr/bin/check_commit.sh
 RUN chmod +x /usr/bin/check_commit.sh
 RUN ln -s /usr/bin/check_commit.sh /usr/bin/check_commit
 
+# Copy X-server wrapper script to container
+COPY wrapper_script.sh /usr/bin/wrapper_script.sh
+RUN chmod +x /usr/bin/wrapper_script.sh
+
 # Copy .zshrc to container
 COPY .zshrc "/home/$user/"
+
+# Make desktop icons and basic panel configuration
+RUN mkdir -p /home/$user/Desktop
+COPY Desktop/Chrome.desktop /home/$user/Desktop/Chrome.desktop
+RUN cp /usr/share/applications/xterm.desktop /home/$user/Desktop/xterm.desktop
+RUN chmod -R +x /home/$user/Desktop
+RUN mkdir -p /home/$user/.config/xfce4
+ADD panel /home/$user/.config/xfce4/panel
+ADD xfconf /home/$user/.config/xfce4/xfconf
+ADD autostart /home/$user/.config/autostart
+RUN sed -i "s/USER_ID/$user/g" /home/$user/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+RUN chown -R "$user:wheel" /home/$user
 
 # Switch to User
 USER "$user"
@@ -86,5 +150,11 @@ ENV PATH      "$NVM_DIR/$NODE_VERSION/bin:$PATH"
 # Change Working directory to home directory
 WORKDIR /home/$user
 
-# Set the entrypoint to bash
+# Set the entrypoint to zsh
 ENTRYPOINT ["/bin/zsh"]
+
+# Expose RDP port
+EXPOSE 3389
+
+# Run supervisord with xrdp
+ENTRYPOINT ["/usr/bin/wrapper_script.sh"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Running image in interactive mode + mounting a fixed directory.
 docker run -it -h docker --mount src=/path/to/folder,target="/home/$USER/workdir/",type=bind 0x4447:latest
 ```
 
+Running the image in interactive mode + RDP listening on port 15050/tcp (remote desktop available on rdp://localhost:15050/)
+
+```sh
+docker run -p 15050:3389 -it -h docker 0x4447:latest
+```
+
 ### Windows
 
 Run the following command in Windows PowerShell:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Running the image in interactive mode + RDP listening on port 15050/tcp (remote 
 docker run -p 15050:3389 -it -h docker 0x4447:latest
 ```
 
+- **Note:** RDP access details will be available in `~/.rdp_credentials` file in form `<username>:<password>`
+
 ### Windows
 
 Run the following command in Windows PowerShell:

--- a/autostart/xfce-polkit.desktop
+++ b/autostart/xfce-polkit.desktop
@@ -1,0 +1,2 @@
+[Desktop Entry]
+Hidden=true

--- a/panel/launcher-10/filemanager.desktop
+++ b/panel/launcher-10/filemanager.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Exec=exo-open --launch FileManager %u
+Icon=system-file-manager
+StartupNotify=true
+Terminal=false
+Categories=Utility;X-XFCE;X-Xfce-Toplevel;
+OnlyShowIn=XFCE;
+X-XFCE-MimeType=inode/directory;x-scheme-handler/trash;
+Name=File Manager
+Comment=Browse the file system
+X-XFCE-Source=file:///usr/share/applications/exo-file-manager.desktop

--- a/panel/launcher-11/webbrowser.desktop
+++ b/panel/launcher-11/webbrowser.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Exec=exo-open --launch WebBrowser %u
+Icon=web-browser
+StartupNotify=true
+Terminal=false
+Categories=Network;X-XFCE;X-Xfce-Toplevel;
+OnlyShowIn=XFCE;
+X-XFCE-MimeType=x-scheme-handler/http;x-scheme-handler/https;
+Name=Web Browser
+Comment=Browse the web
+X-XFCE-Source=file:///usr/share/applications/exo-web-browser.desktop

--- a/panel/launcher-9/terminal.desktop
+++ b/panel/launcher-9/terminal.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Exec=exo-open --launch TerminalEmulator
+Icon=utilities-terminal
+StartupNotify=true
+Terminal=false
+Categories=Utility;X-XFCE;X-Xfce-Toplevel;
+OnlyShowIn=XFCE;
+Name=Terminal Emulator
+Comment=Use the command line
+X-XFCE-Source=file:///usr/share/applications/exo-terminal-emulator.desktop

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,38 @@
+; supervisor config file
+
+[supervisord]
+nodaemon=false
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=http://localhost:9001
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[inet_http_server]
+port = :9001
+[unix_http_server]
+file=/var/run/supervisor.sock   ; (the path to the socket file)
+chmod=0777                       ; sockef file mode (default 0700)
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisord.d/*.ini
+
+[supervisord]
+nodaemon=false

--- a/wrapper_script.sh
+++ b/wrapper_script.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sudo mkdir -p /run/dbus
+sudo dbus-daemon --config-file=/usr/share/dbus-1/system.conf
+sudo supervisord -c /etc/supervisord.conf
+/bin/zsh

--- a/xfconf/xfce-perchannel-xml/thunar.xml
+++ b/xfconf/xfce-perchannel-xml/thunar.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="thunar" version="1.0">
+  <property name="last-view" type="string" value="ThunarIconView"/>
+</channel>

--- a/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
+++ b/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="xfce4-desktop" version="1.0">
+  <property name="backdrop" type="empty">
+    <property name="screen0" type="empty">
+      <property name="monitor0" type="empty">
+        <property name="workspace0" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="5"/>
+          <property name="last-image" type="string" value="/usr/share/backgrounds/images/default.png"/>
+        </property>
+        <property name="workspace1" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="5"/>
+          <property name="last-image" type="string" value="/usr/share/backgrounds/images/default.png"/>
+        </property>
+        <property name="workspace2" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="5"/>
+          <property name="last-image" type="string" value="/usr/share/backgrounds/images/default.png"/>
+        </property>
+        <property name="workspace3" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="5"/>
+          <property name="last-image" type="string" value="/usr/share/backgrounds/images/default.png"/>
+        </property>
+      </property>
+    </property>
+  </property>
+</channel>

--- a/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
+++ b/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="xfce4-keyboard-shortcuts" version="1.0">
+  <property name="commands" type="empty">
+    <property name="default" type="empty">
+      <property name="&lt;Alt&gt;F1" type="empty"/>
+      <property name="&lt;Alt&gt;F2" type="empty">
+        <property name="startup-notify" type="empty"/>
+      </property>
+      <property name="&lt;Alt&gt;F3" type="empty">
+        <property name="startup-notify" type="empty"/>
+      </property>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Delete" type="empty"/>
+      <property name="&lt;Control&gt;&lt;Alt&gt;Escape" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;l" type="empty"/>
+      <property name="XF86Display" type="empty"/>
+      <property name="&lt;Super&gt;p" type="empty"/>
+      <property name="&lt;Primary&gt;Escape" type="empty"/>
+      <property name="XF86LogOff" type="empty"/>
+      <property name="&lt;Control&gt;&lt;Alt&gt;L" type="empty"/>
+      <property name="Print" type="empty"/>
+      <property name="&lt;Alt&gt;Print" type="empty"/>
+      <property name="XF86WWW" type="empty"/>
+      <property name="XF86Mail" type="empty"/>
+      <property name="XF86Calendar" type="empty"/>
+      <property name="XF86Memo" type="empty"/>
+      <property name="XF86Terminal" type="empty"/>
+      <property name="XF86Explorer" type="empty"/>
+      <property name="XF86AudioMedia" type="empty"/>
+      <property name="XF86AudioPlay" type="empty"/>
+      <property name="XF86AudioPrev" type="empty"/>
+      <property name="XF86AudioNext" type="empty"/>
+      <property name="XF86Calculator" type="empty"/>
+    </property>
+  </property>
+  <property name="xfwm4" type="empty">
+    <property name="default" type="empty">
+      <property name="&lt;Alt&gt;Insert" type="empty"/>
+      <property name="Escape" type="empty"/>
+      <property name="Left" type="empty"/>
+      <property name="Right" type="empty"/>
+      <property name="Up" type="empty"/>
+      <property name="Down" type="empty"/>
+      <property name="&lt;Alt&gt;Tab" type="empty"/>
+      <property name="&lt;Alt&gt;&lt;Shift&gt;Tab" type="empty"/>
+      <property name="&lt;Alt&gt;Delete" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Down" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Left" type="empty"/>
+      <property name="&lt;Shift&gt;&lt;Alt&gt;Page_Down" type="empty"/>
+      <property name="&lt;Alt&gt;F4" type="empty"/>
+      <property name="&lt;Alt&gt;F6" type="empty"/>
+      <property name="&lt;Alt&gt;F7" type="empty"/>
+      <property name="&lt;Alt&gt;F8" type="empty"/>
+      <property name="&lt;Alt&gt;F9" type="empty"/>
+      <property name="&lt;Alt&gt;F10" type="empty"/>
+      <property name="&lt;Alt&gt;F11" type="empty"/>
+      <property name="&lt;Alt&gt;F12" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Shift&gt;&lt;Alt&gt;Left" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;End" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Home" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Shift&gt;&lt;Alt&gt;Right" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Shift&gt;&lt;Alt&gt;Up" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_1" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_2" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_3" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_4" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_5" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_6" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_7" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_8" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_9" type="empty"/>
+      <property name="&lt;Alt&gt;space" type="empty"/>
+      <property name="&lt;Shift&gt;&lt;Alt&gt;Page_Up" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Right" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;d" type="empty"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Up" type="empty"/>
+      <property name="&lt;Super&gt;Tab" type="empty"/>
+      <property name="&lt;Primary&gt;F1" type="empty"/>
+      <property name="&lt;Primary&gt;F2" type="empty"/>
+      <property name="&lt;Primary&gt;F3" type="empty"/>
+      <property name="&lt;Primary&gt;F4" type="empty"/>
+      <property name="&lt;Primary&gt;F5" type="empty"/>
+      <property name="&lt;Primary&gt;F6" type="empty"/>
+      <property name="&lt;Primary&gt;F7" type="empty"/>
+      <property name="&lt;Primary&gt;F8" type="empty"/>
+      <property name="&lt;Primary&gt;F9" type="empty"/>
+      <property name="&lt;Primary&gt;F10" type="empty"/>
+      <property name="&lt;Primary&gt;F11" type="empty"/>
+      <property name="&lt;Primary&gt;F12" type="empty"/>
+    </property>
+    <property name="custom" type="empty">
+      <property name="Up" type="string" value="up_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_9" type="string" value="move_window_workspace_9_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_8" type="string" value="move_window_workspace_8_key"/>
+      <property name="Left" type="string" value="left_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_6" type="string" value="move_window_workspace_6_key"/>
+      <property name="&lt;Alt&gt;Insert" type="string" value="add_workspace_key"/>
+      <property name="&lt;Alt&gt;Tab" type="string" value="cycle_windows_key"/>
+      <property name="&lt;Alt&gt;&lt;Shift&gt;Tab" type="string" value="cycle_reverse_windows_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_7" type="string" value="move_window_workspace_7_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Right" type="string" value="right_workspace_key"/>
+      <property name="&lt;Primary&gt;&lt;Shift&gt;&lt;Alt&gt;Right" type="string" value="move_window_right_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;d" type="string" value="show_desktop_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Up" type="string" value="up_workspace_key"/>
+      <property name="&lt;Primary&gt;F7" type="string" value="workspace_7_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Home" type="string" value="move_window_prev_workspace_key"/>
+      <property name="&lt;Alt&gt;F4" type="string" value="close_window_key"/>
+      <property name="&lt;Primary&gt;&lt;Shift&gt;&lt;Alt&gt;Left" type="string" value="move_window_left_key"/>
+      <property name="&lt;Alt&gt;F6" type="string" value="stick_window_key"/>
+      <property name="&lt;Alt&gt;F10" type="string" value="maximize_window_key"/>
+      <property name="&lt;Alt&gt;F12" type="string" value="above_key"/>
+      <property name="&lt;Alt&gt;F9" type="string" value="hide_window_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Down" type="string" value="down_workspace_key"/>
+      <property name="&lt;Alt&gt;F8" type="string" value="resize_window_key"/>
+      <property name="&lt;Super&gt;Tab" type="string" value="switch_window_key"/>
+      <property name="Escape" type="string" value="cancel_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;End" type="string" value="move_window_next_workspace_key"/>
+      <property name="&lt;Primary&gt;F10" type="string" value="workspace_10_key"/>
+      <property name="&lt;Primary&gt;F11" type="string" value="workspace_11_key"/>
+      <property name="&lt;Alt&gt;F11" type="string" value="fullscreen_key"/>
+      <property name="&lt;Primary&gt;&lt;Shift&gt;&lt;Alt&gt;Up" type="string" value="move_window_up_key"/>
+      <property name="Right" type="string" value="right_key"/>
+      <property name="Down" type="string" value="down_key"/>
+      <property name="&lt;Alt&gt;F7" type="string" value="move_window_key"/>
+      <property name="&lt;Shift&gt;&lt;Alt&gt;Page_Down" type="string" value="lower_window_key"/>
+      <property name="&lt;Primary&gt;F12" type="string" value="workspace_12_key"/>
+      <property name="&lt;Primary&gt;F1" type="string" value="workspace_1_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;Left" type="string" value="left_workspace_key"/>
+      <property name="&lt;Primary&gt;F2" type="string" value="workspace_2_key"/>
+      <property name="&lt;Primary&gt;F4" type="string" value="workspace_4_key"/>
+      <property name="&lt;Primary&gt;F5" type="string" value="workspace_5_key"/>
+      <property name="&lt;Primary&gt;F6" type="string" value="workspace_6_key"/>
+      <property name="&lt;Alt&gt;space" type="string" value="popup_menu_key"/>
+      <property name="&lt;Primary&gt;F8" type="string" value="workspace_8_key"/>
+      <property name="&lt;Primary&gt;F9" type="string" value="workspace_9_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_1" type="string" value="move_window_workspace_1_key"/>
+      <property name="&lt;Alt&gt;Delete" type="string" value="del_workspace_key"/>
+      <property name="&lt;Shift&gt;&lt;Alt&gt;Page_Up" type="string" value="raise_window_key"/>
+      <property name="&lt;Primary&gt;F3" type="string" value="workspace_3_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_2" type="string" value="move_window_workspace_2_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_3" type="string" value="move_window_workspace_3_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_4" type="string" value="move_window_workspace_4_key"/>
+      <property name="&lt;Primary&gt;&lt;Alt&gt;KP_5" type="string" value="move_window_workspace_5_key"/>
+      <property name="override" type="bool" value="true"/>
+    </property>
+  </property>
+  <property name="providers" type="array">
+    <value type="string" value="xfwm4"/>
+  </property>
+</channel>

--- a/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="xfce4-panel" version="1.0">
+  <property name="configver" type="int" value="2"/>
+  <property name="panels" type="array">
+    <value type="int" value="1"/>
+    <value type="int" value="2"/>
+    <property name="panel-1" type="empty">
+      <property name="position" type="string" value="p=6;x=0;y=0"/>
+      <property name="length" type="uint" value="100"/>
+      <property name="position-locked" type="bool" value="true"/>
+      <property name="size" type="uint" value="30"/>
+      <property name="plugin-ids" type="array">
+        <value type="int" value="1"/>
+        <value type="int" value="3"/>
+        <value type="int" value="15"/>
+        <value type="int" value="4"/>
+        <value type="int" value="5"/>
+        <value type="int" value="6"/>
+        <value type="int" value="2"/>
+      </property>
+    </property>
+    <property name="panel-2" type="empty">
+      <property name="position" type="string" value="p=10;x=0;y=0"/>
+      <property name="position-locked" type="bool" value="true"/>
+      <property name="plugin-ids" type="array">
+        <value type="int" value="7"/>
+        <value type="int" value="8"/>
+        <value type="int" value="9"/>
+        <value type="int" value="10"/>
+        <value type="int" value="11"/>
+        <value type="int" value="12"/>
+        <value type="int" value="13"/>
+        <value type="int" value="14"/>
+      </property>
+    </property>
+  </property>
+  <property name="plugins" type="empty">
+    <property name="plugin-1" type="string" value="applicationsmenu"/>
+    <property name="plugin-2" type="string" value="actions"/>
+    <property name="plugin-3" type="string" value="tasklist"/>
+    <property name="plugin-15" type="string" value="separator">
+      <property name="expand" type="bool" value="true"/>
+      <property name="style" type="uint" value="0"/>
+    </property>
+    <property name="plugin-4" type="string" value="pager"/>
+    <property name="plugin-5" type="string" value="clock"/>
+    <property name="plugin-6" type="string" value="systray"/>
+    <property name="plugin-7" type="string" value="showdesktop"/>
+    <property name="plugin-8" type="string" value="separator"/>
+    <property name="plugin-9" type="string" value="launcher">
+      <property name="items" type="array">
+        <value type="string" value="terminal.desktop"/>
+      </property>
+    </property>
+    <property name="plugin-10" type="string" value="launcher">
+      <property name="items" type="array">
+        <value type="string" value="filemanager.desktop"/>
+      </property>
+    </property>
+    <property name="plugin-11" type="string" value="launcher">
+      <property name="items" type="array">
+        <value type="string" value="webbrowser.desktop"/>
+      </property>
+    </property>
+    <property name="plugin-12" type="string" value="launcher">
+      <property name="items" type="array">
+      </property>
+    </property>
+    <property name="plugin-13" type="string" value="separator"/>
+    <property name="plugin-14" type="string" value="directorymenu">
+      <property name="base-directory" type="string" value="/home/USER_ID"/>
+    </property>
+  </property>
+</channel>

--- a/xfconf/xfce-perchannel-xml/xfwm4.xml
+++ b/xfconf/xfce-perchannel-xml/xfwm4.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="xfwm4" version="1.0">
+  <property name="general" type="empty">
+    <property name="activate_action" type="string" value="bring"/>
+    <property name="borderless_maximize" type="bool" value="true"/>
+    <property name="box_move" type="bool" value="false"/>
+    <property name="box_resize" type="bool" value="false"/>
+    <property name="button_layout" type="string" value="O|SHMC"/>
+    <property name="button_offset" type="int" value="0"/>
+    <property name="button_spacing" type="int" value="0"/>
+    <property name="click_to_focus" type="bool" value="true"/>
+    <property name="cycle_apps_only" type="bool" value="false"/>
+    <property name="cycle_draw_frame" type="bool" value="true"/>
+    <property name="cycle_hidden" type="bool" value="true"/>
+    <property name="cycle_minimum" type="bool" value="true"/>
+    <property name="cycle_preview" type="bool" value="true"/>
+    <property name="cycle_tabwin_mode" type="int" value="0"/>
+    <property name="cycle_workspaces" type="bool" value="false"/>
+    <property name="double_click_action" type="string" value="maximize"/>
+    <property name="double_click_distance" type="int" value="5"/>
+    <property name="double_click_time" type="int" value="250"/>
+    <property name="easy_click" type="string" value="Alt"/>
+    <property name="focus_delay" type="int" value="250"/>
+    <property name="focus_hint" type="bool" value="true"/>
+    <property name="focus_new" type="bool" value="true"/>
+    <property name="frame_opacity" type="int" value="100"/>
+    <property name="full_width_title" type="bool" value="true"/>
+    <property name="horiz_scroll_opacity" type="bool" value="false"/>
+    <property name="inactive_opacity" type="int" value="100"/>
+    <property name="maximized_offset" type="int" value="0"/>
+    <property name="mousewheel_rollup" type="bool" value="true"/>
+    <property name="move_opacity" type="int" value="100"/>
+    <property name="placement_mode" type="string" value="center"/>
+    <property name="placement_ratio" type="int" value="20"/>
+    <property name="popup_opacity" type="int" value="100"/>
+    <property name="prevent_focus_stealing" type="bool" value="false"/>
+    <property name="raise_delay" type="int" value="250"/>
+    <property name="raise_on_click" type="bool" value="true"/>
+    <property name="raise_on_focus" type="bool" value="false"/>
+    <property name="raise_with_any_button" type="bool" value="true"/>
+    <property name="repeat_urgent_blink" type="bool" value="false"/>
+    <property name="resize_opacity" type="int" value="100"/>
+    <property name="scroll_workspaces" type="bool" value="true"/>
+    <property name="shadow_delta_height" type="int" value="0"/>
+    <property name="shadow_delta_width" type="int" value="0"/>
+    <property name="shadow_delta_x" type="int" value="0"/>
+    <property name="shadow_delta_y" type="int" value="-3"/>
+    <property name="shadow_opacity" type="int" value="50"/>
+    <property name="show_app_icon" type="bool" value="false"/>
+    <property name="show_dock_shadow" type="bool" value="true"/>
+    <property name="show_frame_shadow" type="bool" value="true"/>
+    <property name="show_popup_shadow" type="bool" value="false"/>
+    <property name="snap_resist" type="bool" value="false"/>
+    <property name="snap_to_border" type="bool" value="true"/>
+    <property name="snap_to_windows" type="bool" value="false"/>
+    <property name="snap_width" type="int" value="10"/>
+    <property name="sync_to_vblank" type="bool" value="false"/>
+    <property name="theme" type="string" value="Default"/>
+    <property name="tile_on_move" type="bool" value="true"/>
+    <property name="title_alignment" type="string" value="center"/>
+    <property name="title_font" type="string" value="Sans Bold 9"/>
+    <property name="title_horizontal_offset" type="int" value="0"/>
+    <property name="titleless_maximize" type="bool" value="false"/>
+    <property name="title_shadow_active" type="string" value="false"/>
+    <property name="title_shadow_inactive" type="string" value="false"/>
+    <property name="title_vertical_offset_active" type="int" value="0"/>
+    <property name="title_vertical_offset_inactive" type="int" value="0"/>
+    <property name="toggle_workspaces" type="bool" value="false"/>
+    <property name="unredirect_overlays" type="bool" value="true"/>
+    <property name="urgent_blink" type="bool" value="false"/>
+    <property name="use_compositing" type="bool" value="true"/>
+    <property name="workspace_count" type="int" value="4"/>
+    <property name="wrap_cycle" type="bool" value="true"/>
+    <property name="wrap_layout" type="bool" value="true"/>
+    <property name="wrap_resistance" type="int" value="10"/>
+    <property name="wrap_windows" type="bool" value="true"/>
+    <property name="wrap_workspaces" type="bool" value="false"/>
+    <property name="zoom_desktop" type="bool" value="true"/>
+  </property>
+</channel>

--- a/xrdp-sesman.conf
+++ b/xrdp-sesman.conf
@@ -1,0 +1,5 @@
+[program:xrdp-sesman]
+command=/usr/sbin/xrdp-sesman --nodaemon
+user=root
+autorestart=true
+priority=400

--- a/xrdp.conf
+++ b/xrdp.conf
@@ -1,0 +1,5 @@
+[program:xrdp]
+command=/usr/sbin/xrdp --nodaemon
+user=root
+autorestart=true
+priority=400


### PR DESCRIPTION
- Added `openssl` package to the Dockerfile
- Added `mc` (Midnight Commander - ncurses based file manager for text mode and xterm usage)
- Added `epel` repository for extra packages installation (X-Server, XRDP, Chromium etc)
- Added XFCE4 as default desktop
- Added pack of helpers packages from `epel` (all what needs for X-Server normal functions)
- Added D-Bus subsystem mandatory environment variable: DBUS_SESSION_BUS_ADDRESS
- Added XFCE4-session as default clients windows manager
- Added supervisord services wrapper (as that impossible to use systemd inside of docker)
- Added `xrdp` and `xrdp-sesman` services to the system with running under `supervisord`
- Added `chromium` brovser installation
- Added `machine-id` generation for D-Bus subsystem functionality
- Added copy of default `xorg.conf` to common place position. And made some small modifications to it. Mostly to disable attempts of direct devices usage. As it impossible in docker because docker doesn't have access to DEVFS
- Added random password generation for RDP user. And storing it in ~/.rdp_credentials
- Added wrapper script for run D-Bus, XRDP and entry point to /bin/zsh
- Added base XFCE4 configuration: Default panel, additional desktop shortcuts to Cromium and X-Term
- Added RDP port (3389/tcp) exposition for remote usage possibility

Issue #34